### PR TITLE
Add INPC to models and context

### DIFF
--- a/DatabaseSampleApp/App.xaml
+++ b/DatabaseSampleApp/App.xaml
@@ -3,5 +3,5 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:DatabaseSampleApp"
-    RequestedTheme="Light">
+    RequestedTheme="Light" >
 </Application>

--- a/DatabaseSampleApp/App.xaml.cs
+++ b/DatabaseSampleApp/App.xaml.cs
@@ -49,7 +49,7 @@ namespace DatabaseSampleApp
 #if DEBUG
             if (System.Diagnostics.Debugger.IsAttached)
             {
-                this.DebugSettings.EnableFrameRateCounter = true;
+                this.DebugSettings.EnableFrameRateCounter = false;
             }
 #endif
             Frame rootFrame = Window.Current.Content as Frame;

--- a/DatabaseSampleApp/Importers/Importer.cs
+++ b/DatabaseSampleApp/Importers/Importer.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using Windows.Data.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace DatabaseSampleApp.Importers
 {
 
     public static class Importers
     {
-        public static List<Website> Import(DbContext context, List<Website> apiWebsites)
+        public static ICollection<Website> Import(DbContext context, ICollection<Website> apiWebsites)
         {
             return Importer<Website, Website>.Import(context, apiWebsites, -1, (dbWebsite, apiWebsite) =>
             {
@@ -28,12 +29,12 @@ namespace DatabaseSampleApp.Importers
             });
         }
 
-        public static List<Blog> Import(DbContext context, List<Blog> apiBlogs, int WebsiteId)
+        public static ICollection<Blog> Import(DbContext context, ICollection<Blog> apiBlogs, int websiteId)
         {
-            return Importer<Blog, Blog>.Import(context, apiBlogs, WebsiteId, (dbBlog, apiBlog) =>
+            return Importer<Blog, Blog>.Import(context, apiBlogs, websiteId, (dbBlog, apiBlog) =>
             {
                 dbBlog.DomainUrl = apiBlog.DomainUrl;
-                dbBlog.WebsiteId = WebsiteId;
+                dbBlog.WebsiteId = websiteId;
                 dbBlog.Foo1 = apiBlog.Foo1;
                 dbBlog.Foo2 = apiBlog.Foo2;
                 dbBlog.Foo3 = apiBlog.Foo3;
@@ -48,13 +49,13 @@ namespace DatabaseSampleApp.Importers
             });
         }
 
-        public static List<Topic> Import(DbContext context, List<Topic> apiTopics, int BlogId)
+        public static ICollection<Topic> Import(DbContext context, ICollection<Topic> apiTopics, int blogId)
         {
-            return Importer<Topic, Topic>.Import(context, apiTopics, BlogId, (dbTopic, apiTopic) =>
+            return Importer<Topic, Topic>.Import(context, apiTopics, blogId, (dbTopic, apiTopic) =>
             {
                 dbTopic.TopicName = apiTopic.TopicName;
                 dbTopic.Url = apiTopic.Url;
-                dbTopic.BlogId = BlogId;
+                dbTopic.BlogId = blogId;
                 dbTopic.Foo1 = apiTopic.Foo1;
                 dbTopic.Foo2 = apiTopic.Foo2;
                 dbTopic.Foo3 = apiTopic.Foo3;
@@ -69,9 +70,9 @@ namespace DatabaseSampleApp.Importers
             });
         }
 
-        public static List<Post> Import(DbContext context, List<Post> apiPosts, int TopicId)
+        public static ICollection<Post> Import(DbContext context, ICollection<Post> apiPosts, int topicId)
         {
-            return Importer<Post, Post>.Import(context, apiPosts, TopicId, (dbPost, apiPost) =>
+            return Importer<Post, Post>.Import(context, apiPosts, topicId, (dbPost, apiPost) =>
             {
                 dbPost.Content = apiPost.Content;
                 dbPost.Foo1 = apiPost.Foo1;
@@ -85,7 +86,7 @@ namespace DatabaseSampleApp.Importers
                 dbPost.Foo9 = apiPost.Foo9;
                 dbPost.Foo10 = apiPost.Foo10;
                 dbPost.Title = apiPost.Title;
-                dbPost.TopicId = TopicId;
+                dbPost.TopicId = topicId;
             });
         }
     }
@@ -95,13 +96,13 @@ namespace DatabaseSampleApp.Importers
     where TDb : BaseModel
     where TApi : IHasServerId
     {
-        public static List<TDb> Import(
+        public static ICollection<TDb> Import(
             DbContext context,
-            List<TApi> webEntities,
+            ICollection<TApi> webEntities,
             int scopeId,
             Action<TDb, TApi> copyFields)
         {
-            var createdAndUpdatedDbEntities = new List<TDb>();
+            var createdAndUpdatedDbEntities = new ObservableHashSet<TDb>();
 
             if (webEntities == null || !webEntities.Any()) { return createdAndUpdatedDbEntities; }
 

--- a/DatabaseSampleApp/MainPage.xaml
+++ b/DatabaseSampleApp/MainPage.xaml
@@ -10,41 +10,62 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <RowDefinition Height="50"  />
+            <RowDefinition Height="70" />
+            <RowDefinition Height="70" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="150" />
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Column="0" Grid.Row="0">Actions</TextBlock>
         <TextBlock Grid.Column="1" Grid.Row="0">Time</TextBlock>
 
-        <Button x:Name="GenerateButton" Grid.Column="0" Grid.Row="1" Content="Generate Data" Tapped="Generate_OnTapped" />
-        <Button x:Name="ImportButton" Grid.Column="0" Grid.Row="2" Content="Start Import" Tapped="Import_OnTapped" />
+        <Button x:Name="GenerateButton" Grid.Column="0" Grid.Row="1" Content="Generate Data" Tapped="Generate_OnTapped" Height="32" Width="115" />
+        <Button x:Name="ImportButton" Grid.Column="0" Grid.Row="2" Content="Start Import" Tapped="Import_OnTapped" Height="32" Margin="0,4" Width="100" />
 
 
         <TextBlock Grid.Column="1" Grid.Row="1">
             <Run Text="Generation time: " />
-            <Run Text="{x:Bind GeneratationTime, Mode=OneWay, TargetNullValue='not run yet'}" />
+            <Run Text="{x:Bind GeneratationTime, Mode=OneWay}" />
             <Run Text=" ms" />
         </TextBlock>
 
         <StackPanel Grid.Column="1" Grid.Row="2">
             <TextBlock>
                 <Run Text="Importer time: " />
-                <Run Text="{x:Bind ImporterTime, Mode=OneWay, TargetNullValue='not run yet'}" />
+                <Run Text="{x:Bind ImporterTime, Mode=OneWay}" />
                 <Run Text=" ms" />
             </TextBlock>
             <TextBlock>
                 <Run Text="Save changes time: " />
-                <Run Text="{x:Bind SaveChangesTime, Mode=OneWay, TargetNullValue='not run yet'}" />
+                <Run Text="{x:Bind SaveChangesTime, Mode=OneWay}" />
+                <Run Text=" ms" />
+            </TextBlock>
+        </StackPanel>
+
+        <Button x:Name="RetrievalButton" Grid.Column="0" Grid.Row="3" Content="Retrieve All Data" Tapped="RetrievalButton_OnTapped" Height="32" Margin="0,4" Width="129" />
+
+        <StackPanel Grid.Column="1" Grid.Row="3">
+            <TextBlock>
+                <Run Text="Query expression time: " />
+                <Run Text="{x:Bind QueryTime, Mode=OneWay}" />
+                <Run Text=" ms" />
+            </TextBlock>
+            <TextBlock>
+                <Run Text="Retrieval (no tracking) time: " />
+                <Run Text="{x:Bind RetrievalNoTrackingTime, Mode=OneWay}" />
+                <Run Text=" ms" />
+            </TextBlock>
+
+            <TextBlock>
+                <Run Text="Retrieval (tracking) time: " />
+                <Run Text="{x:Bind RetrievalTrackingTime, Mode=OneWay}" />
                 <Run Text=" ms" />
             </TextBlock>
 
         </StackPanel>
-
 
     </Grid>
 </Page>

--- a/DatabaseSampleApp/MainPage.xaml
+++ b/DatabaseSampleApp/MainPage.xaml
@@ -5,10 +5,46 @@
     xmlns:local="using:DatabaseSampleApp"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d" >
 
-    <StackPanel Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <Button Content="Start Import" Tapped="Import_OnTapped"/>
-        <Button Content="Generate Data" Tapped="Generate_OnTapped"></Button>
-    </StackPanel>
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Column="0" Grid.Row="0">Actions</TextBlock>
+        <TextBlock Grid.Column="1" Grid.Row="0">Time</TextBlock>
+
+        <Button x:Name="GenerateButton" Grid.Column="0" Grid.Row="1" Content="Generate Data" Tapped="Generate_OnTapped" />
+        <Button x:Name="ImportButton" Grid.Column="0" Grid.Row="2" Content="Start Import" Tapped="Import_OnTapped" />
+
+
+        <TextBlock Grid.Column="1" Grid.Row="1">
+            <Run Text="Generation time: " />
+            <Run Text="{x:Bind GeneratationTime, Mode=OneWay, TargetNullValue='not run yet'}" />
+            <Run Text=" ms" />
+        </TextBlock>
+
+        <StackPanel Grid.Column="1" Grid.Row="2">
+            <TextBlock>
+                <Run Text="Importer time: " />
+                <Run Text="{x:Bind ImporterTime, Mode=OneWay, TargetNullValue='not run yet'}" />
+                <Run Text=" ms" />
+            </TextBlock>
+            <TextBlock>
+                <Run Text="Save changes time: " />
+                <Run Text="{x:Bind SaveChangesTime, Mode=OneWay, TargetNullValue='not run yet'}" />
+                <Run Text=" ms" />
+            </TextBlock>
+
+        </StackPanel>
+
+
+    </Grid>
 </Page>

--- a/DatabaseSampleApp/MainPage.xaml
+++ b/DatabaseSampleApp/MainPage.xaml
@@ -23,8 +23,11 @@
         <TextBlock Grid.Column="1" Grid.Row="0">Time</TextBlock>
 
         <Button x:Name="GenerateButton" Grid.Column="0" Grid.Row="1" Content="Generate Data" Tapped="Generate_OnTapped" Height="32" Width="115" />
-        <Button x:Name="ImportButton" Grid.Column="0" Grid.Row="2" Content="Start Import" Tapped="Import_OnTapped" Height="32" Margin="0,4" Width="100" />
 
+        <StackPanel Grid.Column="0" Grid.Row="2">
+            <CheckBox IsChecked="{x:Bind UseInpc, Mode=TwoWay}" Content="Use INPC"/>
+            <Button x:Name="ImportButton" Content="Start Import" Tapped="Import_OnTapped" Height="32" Margin="0,4" Width="100" />
+        </StackPanel>
 
         <TextBlock Grid.Column="1" Grid.Row="1">
             <Run Text="Generation time: " />

--- a/DatabaseSampleApp/MainPage.xaml
+++ b/DatabaseSampleApp/MainPage.xaml
@@ -25,7 +25,6 @@
         <Button x:Name="GenerateButton" Grid.Column="0" Grid.Row="1" Content="Generate Data" Tapped="Generate_OnTapped" Height="32" Width="115" />
 
         <StackPanel Grid.Column="0" Grid.Row="2">
-            <CheckBox IsChecked="{x:Bind UseInpc, Mode=TwoWay}" Content="Use INPC"/>
             <Button x:Name="ImportButton" Content="Start Import" Tapped="Import_OnTapped" Height="32" Margin="0,4" Width="100" />
         </StackPanel>
 

--- a/DatabaseSampleApp/MainPage.xaml.cs
+++ b/DatabaseSampleApp/MainPage.xaml.cs
@@ -63,6 +63,7 @@ namespace DatabaseSampleApp
         {
             GenerateButton.IsEnabled = enabled;
             ImportButton.IsEnabled = enabled;
+            RetrievalButton.IsEnabled = enabled;
         }
 
         private void Generate_OnTapped(object sender, TappedRoutedEventArgs e)
@@ -163,23 +164,6 @@ namespace DatabaseSampleApp
             }
         }
 
-
-        //public static readonly DependencyProperty UseInpcProperty = DependencyProperty.Register(
-        //    "UseInpc", typeof(bool), typeof(MainPage), new PropertyMetadata(default(bool)));
-
-        //public bool UseInpc
-        //{
-        //    get { return (bool) GetValue(UseInpcProperty); }
-        //    set { SetValue(UseInpcProperty, value); }
-        //}
-
-        private bool? _useInpc = true;
-
-        public bool? UseInpc
-        {
-            get { return _useInpc; }
-            set { SetProperty(ref _useInpc, value); }
-        }
 
         private long? _generationTime;
 

--- a/DatabaseSampleApp/MainPage.xaml.cs
+++ b/DatabaseSampleApp/MainPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Microsoft.EntityFrameworkCore;
@@ -72,6 +73,7 @@ namespace DatabaseSampleApp
         private static int generateInt = 0;
 
         private static List<Website> fakeApiData;
+        
 
         public List<Website> GenerateFakeApiData()
         {
@@ -161,7 +163,25 @@ namespace DatabaseSampleApp
             }
         }
 
-        private static long? _generationTime;
+
+        //public static readonly DependencyProperty UseInpcProperty = DependencyProperty.Register(
+        //    "UseInpc", typeof(bool), typeof(MainPage), new PropertyMetadata(default(bool)));
+
+        //public bool UseInpc
+        //{
+        //    get { return (bool) GetValue(UseInpcProperty); }
+        //    set { SetValue(UseInpcProperty, value); }
+        //}
+
+        private bool? _useInpc = true;
+
+        public bool? UseInpc
+        {
+            get { return _useInpc; }
+            set { SetProperty(ref _useInpc, value); }
+        }
+
+        private long? _generationTime;
 
         public long? GeneratationTime
         {
@@ -169,7 +189,7 @@ namespace DatabaseSampleApp
             set { SetProperty(ref _generationTime, value); }
         }
 
-        private static long? _importerTime;
+        private long? _importerTime;
 
         public long? ImporterTime
         {
@@ -177,7 +197,7 @@ namespace DatabaseSampleApp
             set { SetProperty(ref _importerTime, value); }
         }
 
-        private static long? _saveChangesTime;
+        private long? _saveChangesTime;
 
         public long? SaveChangesTime
         {
@@ -185,7 +205,7 @@ namespace DatabaseSampleApp
             set { SetProperty(ref _saveChangesTime, value); }
         }
 
-        private static long? _retrievalNoTrackingTime;
+        private long? _retrievalNoTrackingTime;
 
         public long? RetrievalNoTrackingTime
         {
@@ -193,7 +213,7 @@ namespace DatabaseSampleApp
             set { SetProperty(ref _retrievalNoTrackingTime, value); }
         }
 
-        private static long? _retrievalTrackingTime;
+        private long? _retrievalTrackingTime;
 
         public long? RetrievalTrackingTime
         {
@@ -201,8 +221,8 @@ namespace DatabaseSampleApp
             set { SetProperty(ref _retrievalTrackingTime, value); }
         }
 
-        private static long? _queryTime;
-
+        private long? _queryTime;
+        
         public long? QueryTime
         {
             get { return _queryTime; }

--- a/DatabaseSampleApp/MainPage.xaml.cs
+++ b/DatabaseSampleApp/MainPage.xaml.cs
@@ -1,18 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -21,25 +14,52 @@ namespace DatabaseSampleApp
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class MainPage : Page
+    public sealed partial class MainPage : Page, INotifyPropertyChanged
     {
+        private Stopwatch StartNewStopwatch()
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+            return sw;
+        }
+
         public MainPage()
         {
             this.InitializeComponent();
         }
 
-
-
-        private void Import_OnTapped(object sender, TappedRoutedEventArgs e)
+        private async void Import_OnTapped(object sender, TappedRoutedEventArgs e)
         {
-            Task.Run(() =>
+            SetButtonState(false);
+            ImporterTime = null;
+            SaveChangesTime = null;
+
+            Stopwatch swImport = new Stopwatch();
+            Stopwatch swSave = new Stopwatch();
+
+            await Task.Run(() =>
             {
                 using (var context = new BloggingContext())
                 {
+                    swImport.Start();
                     Importers.Importers.Import(context, fakeApiData);
+                    swImport.Stop();
+
+                    swSave.Start();
                     context.SaveChanges();
+                    swSave.Stop();
                 }
             });
+
+            ImporterTime = swImport.ElapsedMilliseconds;
+            SaveChangesTime = swSave.ElapsedMilliseconds;
+            SetButtonState(true);
+        }
+
+        private void SetButtonState(bool enabled)
+        {
+            GenerateButton.IsEnabled = enabled;
+            ImportButton.IsEnabled = enabled;
         }
 
         private void Generate_OnTapped(object sender, TappedRoutedEventArgs e)
@@ -51,83 +71,140 @@ namespace DatabaseSampleApp
 
         private static List<Website> fakeApiData;
 
-        public static List<Website> GenerateFakeApiData()
+        public List<Website> GenerateFakeApiData()
         {
-            List<Website> fakeWebsites = new List<Website>();
-            for (int x = 0; x < 2; x++)
+            var sw = StartNewStopwatch();
+            try
             {
-                var w = new Website();
-                w.ServerId = generateInt++;
-                w.Foo1 = Guid.NewGuid().ToString();
-                w.Foo2 = Guid.NewGuid().ToString();
-                w.Foo3 = Guid.NewGuid().ToString();
-                w.Foo4 = Guid.NewGuid().ToString();
-                w.Foo5 = Guid.NewGuid().ToString();
-                w.Foo6 = Guid.NewGuid().ToString();
-                w.Foo7 = Guid.NewGuid().ToString();
-                w.Foo8 = Guid.NewGuid().ToString();
-                w.Foo9 = Guid.NewGuid().ToString();
-                w.Foo10 = Guid.NewGuid().ToString();
-                w.Url = Guid.NewGuid().ToString();
-                w.Blogs = new List<Blog>();
-                for (int i = 0; i < 3; i++)
+                List<Website> fakeWebsites = new List<Website>();
+                for (int x = 0; x < 2; x++)
                 {
-                    var b = new Blog();
-                    b.ServerId = generateInt++;
-                    b.Foo1 = Guid.NewGuid().ToString();
-                    b.Foo2 = Guid.NewGuid().ToString();
-                    b.Foo3 = Guid.NewGuid().ToString();
-                    b.Foo4 = Guid.NewGuid().ToString();
-                    b.Foo5 = Guid.NewGuid().ToString();
-                    b.Foo6 = Guid.NewGuid().ToString();
-                    b.Foo7 = Guid.NewGuid().ToString();
-                    b.Foo8 = Guid.NewGuid().ToString();
-                    b.Foo9 = Guid.NewGuid().ToString();
-                    b.Foo10 = Guid.NewGuid().ToString();
-                    b.DomainUrl = Guid.NewGuid().ToString();
-                    b.Topics = new List<Topic>();
-                    for (int j = 0; j < 7; j++)
+                    var w = new Website();
+                    w.ServerId = generateInt++;
+                    w.Foo1 = Guid.NewGuid().ToString();
+                    w.Foo2 = Guid.NewGuid().ToString();
+                    w.Foo3 = Guid.NewGuid().ToString();
+                    w.Foo4 = Guid.NewGuid().ToString();
+                    w.Foo5 = Guid.NewGuid().ToString();
+                    w.Foo6 = Guid.NewGuid().ToString();
+                    w.Foo7 = Guid.NewGuid().ToString();
+                    w.Foo8 = Guid.NewGuid().ToString();
+                    w.Foo9 = Guid.NewGuid().ToString();
+                    w.Foo10 = Guid.NewGuid().ToString();
+                    w.Url = Guid.NewGuid().ToString();
+                    w.Blogs = new List<Blog>();
+                    for (int i = 0; i < 3; i++)
                     {
-                        var t = new Topic();
-                        t.ServerId = generateInt++;
-                        t.Foo1 = Guid.NewGuid().ToString();
-                        t.Foo2 = Guid.NewGuid().ToString();
-                        t.Foo3 = Guid.NewGuid().ToString();
-                        t.Foo4 = Guid.NewGuid().ToString();
-                        t.Foo5 = Guid.NewGuid().ToString();
-                        t.Foo6 = Guid.NewGuid().ToString();
-                        t.Foo7 = Guid.NewGuid().ToString();
-                        t.Foo8 = Guid.NewGuid().ToString();
-                        t.Foo9 = Guid.NewGuid().ToString();
-                        t.Foo10 = Guid.NewGuid().ToString();
-                        t.TopicName = Guid.NewGuid().ToString();
-                        t.Url = Guid.NewGuid().ToString();
-                        t.Posts = new List<Post>();
-                        for (int k = 0; k < 20; k++)
+                        var b = new Blog();
+                        b.ServerId = generateInt++;
+                        b.Foo1 = Guid.NewGuid().ToString();
+                        b.Foo2 = Guid.NewGuid().ToString();
+                        b.Foo3 = Guid.NewGuid().ToString();
+                        b.Foo4 = Guid.NewGuid().ToString();
+                        b.Foo5 = Guid.NewGuid().ToString();
+                        b.Foo6 = Guid.NewGuid().ToString();
+                        b.Foo7 = Guid.NewGuid().ToString();
+                        b.Foo8 = Guid.NewGuid().ToString();
+                        b.Foo9 = Guid.NewGuid().ToString();
+                        b.Foo10 = Guid.NewGuid().ToString();
+                        b.DomainUrl = Guid.NewGuid().ToString();
+                        b.Topics = new List<Topic>();
+                        for (int j = 0; j < 7; j++)
                         {
-                            var p = new Post();
-                            p.ServerId = generateInt++;
-                            p.Foo1 = Guid.NewGuid().ToString();
-                            p.Foo2 = Guid.NewGuid().ToString();
-                            p.Foo3 = Guid.NewGuid().ToString();
-                            p.Foo4 = Guid.NewGuid().ToString();
-                            p.Foo5 = Guid.NewGuid().ToString();
-                            p.Foo6 = Guid.NewGuid().ToString();
-                            p.Foo7 = Guid.NewGuid().ToString();
-                            p.Foo8 = Guid.NewGuid().ToString();
-                            p.Foo9 = Guid.NewGuid().ToString();
-                            p.Foo10 = Guid.NewGuid().ToString();
-                            p.Content = Guid.NewGuid().ToString();
-                            p.Title = Guid.NewGuid().ToString();
-                            t.Posts.Add(p);
+                            var t = new Topic();
+                            t.ServerId = generateInt++;
+                            t.Foo1 = Guid.NewGuid().ToString();
+                            t.Foo2 = Guid.NewGuid().ToString();
+                            t.Foo3 = Guid.NewGuid().ToString();
+                            t.Foo4 = Guid.NewGuid().ToString();
+                            t.Foo5 = Guid.NewGuid().ToString();
+                            t.Foo6 = Guid.NewGuid().ToString();
+                            t.Foo7 = Guid.NewGuid().ToString();
+                            t.Foo8 = Guid.NewGuid().ToString();
+                            t.Foo9 = Guid.NewGuid().ToString();
+                            t.Foo10 = Guid.NewGuid().ToString();
+                            t.TopicName = Guid.NewGuid().ToString();
+                            t.Url = Guid.NewGuid().ToString();
+                            t.Posts = new List<Post>();
+                            for (int k = 0; k < 20; k++)
+                            {
+                                var p = new Post();
+                                p.ServerId = generateInt++;
+                                p.Foo1 = Guid.NewGuid().ToString();
+                                p.Foo2 = Guid.NewGuid().ToString();
+                                p.Foo3 = Guid.NewGuid().ToString();
+                                p.Foo4 = Guid.NewGuid().ToString();
+                                p.Foo5 = Guid.NewGuid().ToString();
+                                p.Foo6 = Guid.NewGuid().ToString();
+                                p.Foo7 = Guid.NewGuid().ToString();
+                                p.Foo8 = Guid.NewGuid().ToString();
+                                p.Foo9 = Guid.NewGuid().ToString();
+                                p.Foo10 = Guid.NewGuid().ToString();
+                                p.Content = Guid.NewGuid().ToString();
+                                p.Title = Guid.NewGuid().ToString();
+                                t.Posts.Add(p);
+                            }
+                            b.Topics.Add(t);
                         }
-                        b.Topics.Add(t);
+                        w.Blogs.Add(b);
                     }
-                    w.Blogs.Add(b);
+                    fakeWebsites.Add(w);
                 }
-                fakeWebsites.Add(w);
+                return fakeWebsites;
             }
-            return fakeWebsites;
+            finally
+            {
+                sw.Stop();
+                GeneratationTime = sw.ElapsedMilliseconds;
+            }
         }
+
+        private static long? _generationTime;
+
+        public long? GeneratationTime
+        {
+            get { return _generationTime; }
+            set { SetProperty(ref _generationTime, value); }
+        }
+
+        private static long? _importerTime;
+
+        public long? ImporterTime
+        {
+            get { return _importerTime; }
+            set { SetProperty(ref _importerTime, value); }
+        }
+
+        private static long? _saveChangesTime;
+
+        public long? SaveChangesTime
+        {
+            get { return _saveChangesTime; }
+            set { SetProperty(ref _saveChangesTime, value); }
+        }
+
+
+
+
+
+        #region PropertyChangeImplementation
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private bool SetProperty<T>(ref T member, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (object.Equals(member, value)) return false;
+
+            member = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #endregion
     }
 }

--- a/DatabaseSampleApp/Model.cs
+++ b/DatabaseSampleApp/Model.cs
@@ -1,6 +1,10 @@
 ﻿
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace DatabaseSampleApp
 {
@@ -15,6 +19,20 @@ namespace DatabaseSampleApp
         {
             optionsBuilder.UseSqlite("Filename=Blogging.db");
         }
+
+
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            if (UseInpc)
+            {
+                modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
+            }
+        }
+
+        private const bool UseInpc = true;
     }
 
     public interface IHasServerId
@@ -22,32 +40,126 @@ namespace DatabaseSampleApp
         int? ServerId { get; }
     }
 
-    public abstract class BaseModel : IHasServerId
+    public abstract class BaseModel : IHasServerId, INotifyPropertyChanged, INotifyPropertyChanging
     {
-        public int? ServerId { get; set; }
+        private int? _serverId;
+
+        public int? ServerId
+        {
+            get { return _serverId; }
+            set { SetProperty(ref _serverId, value); }
+        }
 
         public abstract int GetScopeId();
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler PropertyChanging;
+
+        protected bool SetProperty<T>(ref T member, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (object.Equals(member, value)) return false;
+
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+            member = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            return true;
+        }
     }
 
 
     public class Website : BaseModel
     {
-        public int? WebsiteId { get; set; }
+        private int? _websiteId;
+        private string _url;
+        private ICollection<Blog> _blogs = new ObservableHashSet<Blog>();
+        private string _foo1;
+        private string _foo2;
+        private string _foo3;
+        private string _foo4;
+        private string _foo5;
+        private string _foo6;
+        private string _foo7;
+        private string _foo8;
+        private string _foo9;
+        private string _foo10;
 
-        public string Url { get; set; }
+        public int? WebsiteId
+        {
+            get { return _websiteId; }
+            set { SetProperty(ref _websiteId, value); }
+        }
 
-        public List<Blog> Blogs { get; set; }
+        public string Url
+        {
+            get { return _url; }
+            set { SetProperty(ref _url, value); }
+        }
 
-        public string Foo1 { get; set; }
-        public string Foo2 { get; set; }
-        public string Foo3 { get; set; }
-        public string Foo4 { get; set; }
-        public string Foo5 { get; set; }
-        public string Foo6 { get; set; }
-        public string Foo7 { get; set; }
-        public string Foo8 { get; set; }
-        public string Foo9 { get; set; }
-        public string Foo10 { get; set; }
+        public ICollection<Blog> Blogs
+        {
+            get { return _blogs; }
+            set { SetProperty(ref _blogs, value); }
+        }
+
+        public string Foo1
+        {
+            get { return _foo1; }
+            set { SetProperty(ref _foo1, value); }
+        }
+
+        public string Foo2
+        {
+            get { return _foo2; }
+            set { SetProperty(ref _foo2, value); }
+        }
+
+        public string Foo3
+        {
+            get { return _foo3; }
+            set { SetProperty(ref _foo3, value); }
+        }
+
+        public string Foo4
+        {
+            get { return _foo4; }
+            set { SetProperty(ref _foo4, value); }
+        }
+
+        public string Foo5
+        {
+            get { return _foo5; }
+            set { SetProperty(ref _foo5, value); }
+        }
+
+        public string Foo6
+        {
+            get { return _foo6; }
+            set { SetProperty(ref _foo6, value); }
+        }
+
+        public string Foo7
+        {
+            get { return _foo7; }
+            set { SetProperty(ref _foo7, value); }
+        }
+
+        public string Foo8
+        {
+            get { return _foo8; }
+            set { SetProperty(ref _foo8, value); }
+        }
+
+        public string Foo9
+        {
+            get { return _foo9; }
+            set { SetProperty(ref _foo9, value); }
+        }
+
+        public string Foo10
+        {
+            get { return _foo10; }
+            set { SetProperty(ref _foo10, value); }
+        }
 
         public override int GetScopeId()
         {
@@ -57,26 +169,111 @@ namespace DatabaseSampleApp
 
     public class Blog : BaseModel
     {
-        public int? BlogId { get; set; }
+        private string _foo1;
+        private string _foo2;
+        private string _foo3;
+        private string _foo4;
+        private string _foo5;
+        private string _foo6;
+        private string _foo7;
+        private string _foo8;
+        private string _foo9;
+        private string _foo10;
+        private int? _blogId;
+        private Website _website;
+        private int _websiteId;
+        private string _domainUrl;
+        private ICollection<Topic> _topics = new ObservableHashSet<Topic>();
 
-        public Website Website { get; set; }
+        public int? BlogId
+        {
+            get { return _blogId; }
+            set { SetProperty(ref _blogId, value); }
+        }
 
-        public int WebsiteId { get; set; }
+        public Website Website
+        {
+            get { return _website; }
+            set { SetProperty(ref _website, value); }
+        }
 
-        public string DomainUrl { get; set; }
+        public int WebsiteId
+        {
+            get { return _websiteId; }
+            set { SetProperty(ref _websiteId, value); }
+        }
 
-        public string Foo1 { get; set; }
-        public string Foo2 { get; set; }
-        public string Foo3 { get; set; }
-        public string Foo4 { get; set; }
-        public string Foo5 { get; set; }
-        public string Foo6 { get; set; }
-        public string Foo7 { get; set; }
-        public string Foo8 { get; set; }
-        public string Foo9 { get; set; }
-        public string Foo10 { get; set; }
+        public string DomainUrl
+        {
+            get { return _domainUrl; }
+            set { SetProperty(ref _domainUrl, value); }
+        }
 
-        public List<Topic> Topics { get; set; }
+        public string Foo1
+        {
+            get { return _foo1; }
+            set { SetProperty(ref _foo1, value); }
+        }
+
+        public string Foo2
+        {
+            get { return _foo2; }
+            set { SetProperty(ref _foo2, value); }
+        }
+
+        public string Foo3
+        {
+            get { return _foo3; }
+            set { SetProperty(ref _foo3, value); }
+        }
+
+        public string Foo4
+        {
+            get { return _foo4; }
+            set { SetProperty(ref _foo4, value); }
+        }
+
+        public string Foo5
+        {
+            get { return _foo5; }
+            set { SetProperty(ref _foo5, value); }
+        }
+
+        public string Foo6
+        {
+            get { return _foo6; }
+            set { SetProperty(ref _foo6, value); }
+        }
+
+        public string Foo7
+        {
+            get { return _foo7; }
+            set { SetProperty(ref _foo7, value); }
+        }
+
+        public string Foo8
+        {
+            get { return _foo8; }
+            set { SetProperty(ref _foo8, value); }
+        }
+
+        public string Foo9
+        {
+            get { return _foo9; }
+            set { SetProperty(ref _foo9, value); }
+        }
+
+        public string Foo10
+        {
+            get { return _foo10; }
+            set { SetProperty(ref _foo10, value); }
+        }
+
+        public ICollection<Topic> Topics
+        {
+            get { return _topics; }
+            set { SetProperty(ref _topics, value); }
+        }
 
         public override int GetScopeId()
         {
@@ -86,28 +283,118 @@ namespace DatabaseSampleApp
 
     public class Topic : BaseModel
     {
-        public int? TopicId { get; set; }
+        private string _foo1;
+        private string _foo2;
+        private string _foo3;
+        private string _foo4;
+        private string _foo5;
+        private string _foo6;
+        private string _foo7;
+        private string _foo8;
+        private string _foo9;
+        private string _foo10;
+        private int? _topicId;
+        private Blog _blog;
+        private int _blogId;
+        private string _topicName;
+        private string _url;
+        private ICollection<Post> _posts = new ObservableHashSet<Post>();
 
-        public Blog Blog { get; set; }
+        public int? TopicId
+        {
+            get { return _topicId; }
+            set { SetProperty(ref _topicId, value); }
+        }
 
-        public int BlogId { get; set; }
+        public Blog Blog
+        {
+            get { return _blog; }
+            set { SetProperty(ref _blog, value); }
+        }
 
-        public string TopicName { get; set; }
+        public int BlogId
+        {
+            get { return _blogId; }
+            set { SetProperty(ref _blogId, value); }
+        }
 
-        public string Url { get; set; }
+        public string TopicName
+        {
+            get { return _topicName; }
+            set { SetProperty(ref _topicName, value); }
+        }
 
-        public string Foo1 { get; set; }
-        public string Foo2 { get; set; }
-        public string Foo3 { get; set; }
-        public string Foo4 { get; set; }
-        public string Foo5 { get; set; }
-        public string Foo6 { get; set; }
-        public string Foo7 { get; set; }
-        public string Foo8 { get; set; }
-        public string Foo9 { get; set; }
-        public string Foo10 { get; set; }
+        public string Url
+        {
+            get { return _url; }
+            set { SetProperty(ref _url, value); }
+        }
 
-        public List<Post> Posts { get; set; }
+        public string Foo1
+        {
+            get { return _foo1; }
+            set { SetProperty(ref _foo1, value); }
+        }
+
+        public string Foo2
+        {
+            get { return _foo2; }
+            set { SetProperty(ref _foo2, value); }
+        }
+
+        public string Foo3
+        {
+            get { return _foo3; }
+            set { SetProperty(ref _foo3, value); }
+        }
+
+        public string Foo4
+        {
+            get { return _foo4; }
+            set { SetProperty(ref _foo4, value); }
+        }
+
+        public string Foo5
+        {
+            get { return _foo5; }
+            set { SetProperty(ref _foo5, value); }
+        }
+
+        public string Foo6
+        {
+            get { return _foo6; }
+            set { SetProperty(ref _foo6, value); }
+        }
+
+        public string Foo7
+        {
+            get { return _foo7; }
+            set { SetProperty(ref _foo7, value); }
+        }
+
+        public string Foo8
+        {
+            get { return _foo8; }
+            set { SetProperty(ref _foo8, value); }
+        }
+
+        public string Foo9
+        {
+            get { return _foo9; }
+            set { SetProperty(ref _foo9, value); }
+        }
+
+        public string Foo10
+        {
+            get { return _foo10; }
+            set { SetProperty(ref _foo10, value); }
+        }
+
+        public ICollection<Post> Posts
+        {
+            get { return _posts; }
+            set { SetProperty(ref _posts, value); }
+        }
 
         public override int GetScopeId()
         {
@@ -117,23 +404,111 @@ namespace DatabaseSampleApp
 
     public class Post : BaseModel
     {
-        public int? PostId { get; set; }
-        public string Title { get; set; }
-        public string Content { get; set; }
+        private string _foo1;
+        private string _foo2;
+        private string _foo3;
+        private string _foo4;
+        private string _foo5;
+        private string _foo6;
+        private string _foo7;
+        private string _foo8;
+        private string _foo9;
+        private string _foo10;
+        private int? _postId;
+        private string _title;
+        private string _content;
+        private int _topicId;
+        private Topic _topic;
 
-        public int TopicId { get; set; }
-        public Topic Topic { get; set; }
+        public int? PostId
+        {
+            get { return _postId; }
+            set { SetProperty(ref _postId, value); }
+        }
 
-        public string Foo1 { get; set; }
-        public string Foo2 { get; set; }
-        public string Foo3 { get; set; }
-        public string Foo4 { get; set; }
-        public string Foo5 { get; set; }
-        public string Foo6 { get; set; }
-        public string Foo7 { get; set; }
-        public string Foo8 { get; set; }
-        public string Foo9 { get; set; }
-        public string Foo10 { get; set; }
+        public string Title
+        {
+            get { return _title; }
+            set { SetProperty(ref _title, value); }
+        }
+
+        public string Content
+        {
+            get { return _content; }
+            set { SetProperty(ref _content, value); }
+        }
+
+        public int TopicId
+        {
+            get { return _topicId; }
+            set { SetProperty(ref _topicId, value); }
+        }
+
+        public Topic Topic
+        {
+            get { return _topic; }
+            set { SetProperty(ref _topic, value); }
+        }
+
+        public string Foo1
+        {
+            get { return _foo1; }
+            set { SetProperty(ref _foo1, value); }
+        }
+
+        public string Foo2
+        {
+            get { return _foo2; }
+            set { SetProperty(ref _foo2, value); }
+        }
+
+        public string Foo3
+        {
+            get { return _foo3; }
+            set { SetProperty(ref _foo3, value); }
+        }
+
+        public string Foo4
+        {
+            get { return _foo4; }
+            set { SetProperty(ref _foo4, value); }
+        }
+
+        public string Foo5
+        {
+            get { return _foo5; }
+            set { SetProperty(ref _foo5, value); }
+        }
+
+        public string Foo6
+        {
+            get { return _foo6; }
+            set { SetProperty(ref _foo6, value); }
+        }
+
+        public string Foo7
+        {
+            get { return _foo7; }
+            set { SetProperty(ref _foo7, value); }
+        }
+
+        public string Foo8
+        {
+            get { return _foo8; }
+            set { SetProperty(ref _foo8, value); }
+        }
+
+        public string Foo9
+        {
+            get { return _foo9; }
+            set { SetProperty(ref _foo9, value); }
+        }
+
+        public string Foo10
+        {
+            get { return _foo10; }
+            set { SetProperty(ref _foo10, value); }
+        }
 
         public override int GetScopeId()
         {


### PR DESCRIPTION
This adds `INotifyPropertyChanged` and `INotifyPropertyChanging` implementations to `BaseModel`. The DbContext also has a change to set the model to use those implementations.

Note: Ignore the branch name, this is actually built against __EF Core 1.0__.